### PR TITLE
Implement TableBuilder and table domain models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Repository guidelines
+
+- Before building or testing ensure custom NuGet packages are available when you need the real ML implementations:
+  1. `mkdir -p packages/custom`
+  2. Download the EasyOCR, layout SDK, and TableFormer packages:
+     ```bash
+     curl -L -o packages/custom/EasyOcrNet.1.0.0.nupkg \
+       https://github.com/mapo80/easyocrnet/releases/download/v2025.09.19/EasyOcrNet.1.0.0.nupkg
+     curl -L -o packages/custom/Docling.LayoutSdk.1.0.2.nupkg \
+       https://github.com/mapo80/ds4sd-docling-layout-heron-onnx/releases/download/models-2025-09-19/Docling.LayoutSdk.1.0.2.nupkg
+     curl -L -o packages/custom/TableFormerSdk.1.0.0.nupkg \
+       https://github.com/mapo80/ds4sd-docling-tableformer-onnx/releases/download/v1.0.0/TableFormerSdk.1.0.0.nupkg
+     ```
+  3. Run `dotnet restore` to hydrate the local cache.
+
+  The runtime projects depend on the **real** EasyOcrNet and Docling.LayoutSdk packages. Do not rely on the legacy stubs: they are reserved for unit tests only and live in the test project when required. Always hydrate the packages before building or running tests.
+
+- To validate changes locally execute `dotnet test`. Coverlet runs automatically and enforces a minimum **90% line coverage** threshold. Investigate any coverage regression before opening a pull request.
+
+- Keep the workspace clean: ensure `dotnet test` passes and leave the git tree without pending changes after completing a task.

--- a/src/Docling.Core/Documents/TableCellItem.cs
+++ b/src/Docling.Core/Documents/TableCellItem.cs
@@ -1,0 +1,14 @@
+using Docling.Core.Geometry;
+
+namespace Docling.Core.Documents;
+
+/// <summary>
+/// Represents the placement of a table cell within a reconstructed grid.
+/// </summary>
+public sealed record TableCellItem(
+    int RowIndex,
+    int ColumnIndex,
+    int RowSpan,
+    int ColumnSpan,
+    BoundingBox BoundingBox,
+    string? Text);

--- a/src/Docling.Core/Documents/TableItem.cs
+++ b/src/Docling.Core/Documents/TableItem.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Docling.Core.Geometry;
+using Docling.Core.Primitives;
+
+namespace Docling.Core.Documents;
+
+/// <summary>
+/// Represents a structured table reconstructed from layout and OCR analysis.
+/// </summary>
+public sealed class TableItem : DocItem
+{
+    private readonly ReadOnlyCollection<TableCellItem> _cells;
+
+    public TableItem(
+        PageReference page,
+        BoundingBox boundingBox,
+        IReadOnlyList<TableCellItem> cells,
+        int rowCount,
+        int columnCount,
+        string? id = null,
+        IEnumerable<string>? tags = null,
+        IReadOnlyDictionary<string, object?>? metadata = null,
+        DateTimeOffset? createdAt = null)
+        : base(DocItemKind.Table, page, boundingBox, id, tags, metadata, createdAt)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(rowCount, nameof(rowCount));
+        ArgumentOutOfRangeException.ThrowIfNegative(columnCount, nameof(columnCount));
+
+        RowCount = rowCount;
+        ColumnCount = columnCount;
+
+        _cells = new ReadOnlyCollection<TableCellItem>(cells?.Count > 0
+            ? new List<TableCellItem>(cells)
+            : new List<TableCellItem>());
+
+        SetMetadata("row_count", RowCount);
+        SetMetadata("column_count", ColumnCount);
+    }
+
+    public int RowCount { get; }
+
+    public int ColumnCount { get; }
+
+    public IReadOnlyList<TableCellItem> Cells => _cells;
+}

--- a/src/Docling.Models/Docling.Models.csproj
+++ b/src/Docling.Models/Docling.Models.csproj
@@ -11,10 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Docling.LayoutSdk" Version="1.0.2" />
+    <PackageReference Include="EasyOcrNet" Version="1.0.0" />
+    <PackageReference Include="TableFormerSdk" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
     <PackageReference Include="SkiaSharp" Version="3.119.0" />
-    <PackageReference Include="EasyOcrNet" Version="1.0.0" />
-    <PackageReference Include="Docling.LayoutSdk" Version="1.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Docling.Models/Layout/LayoutSdkRunner.cs
+++ b/src/Docling.Models/Layout/LayoutSdkRunner.cs
@@ -40,7 +40,11 @@ internal sealed partial class LayoutSdkRunner : ILayoutSdkRunner
         var sdkOptions = CreateSdkOptions(_options);
         var backendFactory = CreateBackendFactory(sdkOptions);
 
-        _sdk = new LayoutSdk.LayoutSdk(sdkOptions, backendFactory, new PassthroughOverlayRenderer(), new SkiaImagePreprocessor());
+        _sdk = new LayoutSdk.LayoutSdk(
+            sdkOptions,
+            backendFactory,
+            new Docling.Models.Layout.PassthroughOverlayRenderer(),
+            new SkiaImagePreprocessor());
         _semaphore = new SemaphoreSlim(_options.MaxDegreeOfParallelism);
         RunnerLogger.Initialized(_logger, _options.Runtime.ToString(), _options.Language.ToString(), _workingDirectory);
     }
@@ -239,12 +243,4 @@ internal sealed partial class LayoutSdkRunner : ILayoutSdkRunner
         public static partial void DeletionFailed(ILogger logger, string path, Exception exception);
     }
 
-    private sealed class PassthroughOverlayRenderer : LayoutSdk.Rendering.IImageOverlayRenderer
-    {
-        public SKBitmap CreateOverlay(SKBitmap image, IReadOnlyList<LayoutSdk.BoundingBox> boxes)
-        {
-            ArgumentNullException.ThrowIfNull(image);
-            return image.Copy();
-        }
-    }
 }

--- a/src/Docling.Models/Layout/PassthroughOverlayRenderer.cs
+++ b/src/Docling.Models/Layout/PassthroughOverlayRenderer.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using LayoutSdk;
+using LayoutSdk.Rendering;
+using SkiaSharp;
+
+namespace Docling.Models.Layout;
+
+internal sealed class PassthroughOverlayRenderer : IImageOverlayRenderer
+{
+    public SKBitmap CreateOverlay(SKBitmap baseImage, IReadOnlyList<BoundingBox> boxes)
+    {
+        ArgumentNullException.ThrowIfNull(baseImage);
+        _ = boxes;
+
+        var clone = baseImage.Copy();
+        if (clone is not null)
+        {
+            return clone;
+        }
+
+        var fallback = new SKBitmap(baseImage.Info);
+        if (!baseImage.CopyTo(fallback))
+        {
+            fallback.Dispose();
+            throw new InvalidOperationException("Failed to clone the layout overlay bitmap.");
+        }
+
+        return fallback;
+    }
+}

--- a/src/Docling.Models/Tables/TableBuilder.cs
+++ b/src/Docling.Models/Tables/TableBuilder.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Docling.Core.Documents;
+using Docling.Core.Geometry;
+
+namespace Docling.Models.Tables;
+
+/// <summary>
+/// Reconstructs a structured <see cref="TableItem"/> from the raw <see cref="TableStructure"/> output
+/// of the TableFormer service.
+/// Mirrors the placement and span reconciliation logic from the Python TableBuilder.
+/// </summary>
+public static class TableBuilder
+{
+    /// <summary>
+    /// Builds a <see cref="TableItem"/> by projecting the supplied <paramref name="structure"/> into a dense grid
+    /// and reconciling row/column spans.
+    /// </summary>
+    /// <param name="structure">TableFormer structure response.</param>
+    /// <returns>A populated <see cref="TableItem"/> ready for pipeline consumption.</returns>
+    public static TableItem Build(TableStructure structure)
+    {
+        ArgumentNullException.ThrowIfNull(structure);
+
+        var cells = structure.Cells ?? Array.Empty<TableCell>();
+        if (cells.Count == 0)
+        {
+            return new TableItem(
+                structure.Page,
+                default,
+                Array.Empty<TableCellItem>(),
+                rowCount: 0,
+                columnCount: 0);
+        }
+
+        var orderedCells = cells
+            .Where(static cell => !cell.BoundingBox.IsEmpty)
+            .OrderBy(static cell => cell.BoundingBox.Top)
+            .ThenBy(static cell => cell.BoundingBox.Left)
+            .ToList();
+
+        if (orderedCells.Count == 0)
+        {
+            return new TableItem(
+                structure.Page,
+                default,
+                Array.Empty<TableCellItem>(),
+                rowCount: 0,
+                columnCount: 0);
+        }
+
+        var rowCount = structure.RowCount > 0
+            ? structure.RowCount
+            : EstimateAxisGroups(orderedCells, static cell => (cell.BoundingBox.Top, cell.BoundingBox.Height));
+        var columnCount = structure.ColumnCount > 0
+            ? structure.ColumnCount
+            : EstimateAxisGroups(orderedCells, static cell => (cell.BoundingBox.Left, cell.BoundingBox.Width));
+
+        if (rowCount <= 0 || columnCount <= 0)
+        {
+            return new TableItem(
+                structure.Page,
+                default,
+                Array.Empty<TableCellItem>(),
+                rowCount: Math.Max(rowCount, 0),
+                columnCount: Math.Max(columnCount, 0));
+        }
+
+        var placements = PlaceCells(orderedCells, rowCount, columnCount);
+        var boundingBox = ComputeBoundingBox(placements);
+
+        return new TableItem(
+            structure.Page,
+            boundingBox,
+            placements,
+            rowCount,
+            columnCount);
+    }
+
+    private static List<TableCellItem> PlaceCells(
+        List<TableCell> cells,
+        int rowCount,
+        int columnCount)
+    {
+        var occupancy = CreateOccupancy(rowCount, columnCount);
+        var placements = new List<TableCellItem>(cells.Count);
+
+        foreach (var cell in cells)
+        {
+            if (!TryFindNextAvailable(occupancy, out var rowIndex, out var columnIndex))
+            {
+                break;
+            }
+
+            var normalizedRowSpan = NormalizeSpan(cell.RowSpan, rowCount - rowIndex);
+            var normalizedColumnSpan = NormalizeSpan(cell.ColumnSpan, columnCount - columnIndex);
+            MarkOccupied(occupancy, rowIndex, columnIndex, normalizedRowSpan, normalizedColumnSpan);
+
+            if (normalizedRowSpan <= 0 || normalizedColumnSpan <= 0)
+            {
+                continue;
+            }
+
+            placements.Add(new TableCellItem(
+                rowIndex,
+                columnIndex,
+                normalizedRowSpan,
+                normalizedColumnSpan,
+                cell.BoundingBox,
+                cell.Text));
+        }
+
+        return placements;
+    }
+
+    private static BoundingBox ComputeBoundingBox(List<TableCellItem> cells)
+    {
+        if (cells.Count == 0)
+        {
+            return default;
+        }
+
+        var bounds = cells[0].BoundingBox;
+        for (var i = 1; i < cells.Count; i++)
+        {
+            bounds = bounds.Union(cells[i].BoundingBox);
+        }
+
+        return bounds;
+    }
+
+    private static int NormalizeSpan(int span, int remaining)
+    {
+        if (remaining <= 0)
+        {
+            return 0;
+        }
+
+        if (span <= 0)
+        {
+            return Math.Min(1, remaining);
+        }
+
+        return Math.Min(span, remaining);
+    }
+
+    private static bool[][] CreateOccupancy(int rows, int columns)
+    {
+        var occupancy = new bool[rows][];
+        for (var r = 0; r < rows; r++)
+        {
+            occupancy[r] = new bool[columns];
+        }
+
+        return occupancy;
+    }
+
+    private static bool TryFindNextAvailable(bool[][] occupancy, out int rowIndex, out int columnIndex)
+    {
+        for (var r = 0; r < occupancy.Length; r++)
+        {
+            var row = occupancy[r];
+            for (var c = 0; c < row.Length; c++)
+            {
+                if (!row[c])
+                {
+                    rowIndex = r;
+                    columnIndex = c;
+                    return true;
+                }
+            }
+        }
+
+        rowIndex = -1;
+        columnIndex = -1;
+        return false;
+    }
+
+    private static void MarkOccupied(bool[][] occupancy, int startRow, int startColumn, int rowSpan, int columnSpan)
+    {
+        var endRow = Math.Min(startRow + Math.Max(rowSpan, 0), occupancy.Length);
+        for (var r = startRow; r < endRow; r++)
+        {
+            var row = occupancy[r];
+            var endColumn = Math.Min(startColumn + Math.Max(columnSpan, 0), row.Length);
+            for (var c = startColumn; c < endColumn; c++)
+            {
+                row[c] = true;
+            }
+        }
+    }
+
+    private static int EstimateAxisGroups(
+        List<TableCell> cells,
+        Func<TableCell, (double Origin, double Length)> selector)
+    {
+        if (cells.Count == 0)
+        {
+            return 0;
+        }
+
+        var centers = new List<double>();
+        foreach (var cell in cells.OrderBy(cell => selector(cell).Origin))
+        {
+            var (origin, length) = selector(cell);
+            var size = Math.Max(length, 1d);
+            var center = origin + (size / 2d);
+            var tolerance = Math.Max(size * 0.5d, 1d);
+
+            var match = centers.FindIndex(existing => Math.Abs(existing - center) <= tolerance);
+            if (match < 0)
+            {
+                centers.Add(center);
+            }
+        }
+
+        return centers.Count;
+    }
+}

--- a/src/Docling.Models/Tables/TableFormerTableStructureService.cs
+++ b/src/Docling.Models/Tables/TableFormerTableStructureService.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Docling.Core.Geometry;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using SkiaSharp;
+using TableFormerSdk;
+using TableFormerSdk.Configuration;
+using TableFormerSdk.Enums;
+using TableFormerSdk.Models;
+
+namespace Docling.Models.Tables;
+
+public sealed class TableFormerStructureServiceOptions
+{
+    public TableFormerModelVariant Variant { get; init; } = TableFormerModelVariant.Accurate;
+
+    public TableFormerRuntime Runtime { get; init; } = TableFormerRuntime.Auto;
+
+    public TableFormerLanguage? Language { get; init; }
+
+    public bool GenerateOverlay { get; init; }
+
+    public TableFormerSdkOptions? SdkOptions { get; init; }
+
+    public string WorkingDirectory { get; init; } = Path.GetTempPath();
+}
+
+public sealed class TableFormerTableStructureService : ITableStructureService, IDisposable
+{
+    private readonly ILogger<TableFormerTableStructureService> _logger;
+    private readonly TableFormerModelVariant _variant;
+    private readonly TableFormerRuntime _runtime;
+    private readonly TableFormerLanguage? _language;
+    private readonly bool _generateOverlay;
+    private readonly string _workingDirectory;
+    private readonly ITableFormerInvoker _tableFormer;
+    private bool _disposed;
+    private static readonly Action<ILogger, string, Exception> LogDeleteFailed = LoggerMessage.Define<string>(
+        LogLevel.Warning,
+        new EventId(1, nameof(TryDelete)),
+        "Failed to delete temporary TableFormer image '{Path}'.");
+
+    public TableFormerTableStructureService(
+        TableFormerStructureServiceOptions? options = null,
+        ILogger<TableFormerTableStructureService>? logger = null)
+        : this(options, logger, tableFormer: null)
+    {
+    }
+
+    internal TableFormerTableStructureService(
+        TableFormerStructureServiceOptions? options,
+        ILogger<TableFormerTableStructureService>? logger,
+        ITableFormerInvoker? tableFormer)
+    {
+        options ??= new TableFormerStructureServiceOptions();
+        _logger = logger ?? NullLogger<TableFormerTableStructureService>.Instance;
+        _variant = options.Variant;
+        _runtime = options.Runtime;
+        _language = options.Language;
+        _generateOverlay = options.GenerateOverlay;
+        _workingDirectory = PrepareWorkingDirectory(options.WorkingDirectory);
+
+        var sdkOptions = options.SdkOptions ?? new TableFormerSdkOptions();
+        _tableFormer = tableFormer ?? new TableFormerInvoker(new TableFormerSdk.TableFormerSdk(sdkOptions));
+    }
+
+    public async Task<TableStructure> InferStructureAsync(TableStructureRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        EnsureNotDisposed();
+
+        if (request.RasterizedImage.IsEmpty)
+        {
+            throw new ArgumentException("Rasterized image payload is empty.", nameof(request));
+        }
+
+        using var imageData = SKData.CreateCopy(request.RasterizedImage.ToArray());
+        using var bitmap = SKBitmap.Decode(imageData);
+        if (bitmap is null)
+        {
+            throw new InvalidOperationException("The provided rasterized image could not be decoded.");
+        }
+
+        if (bitmap.Width <= 0 || bitmap.Height <= 0)
+        {
+            throw new InvalidOperationException("The rasterized image has invalid dimensions.");
+        }
+
+        var tempPath = Path.Combine(_workingDirectory, $"docling-tableformer-{Guid.NewGuid():N}.png");
+        using var stream = new FileStream(tempPath, FileMode.CreateNew, FileAccess.Write, FileShare.Read, bufferSize: 4096, useAsync: true);
+        await stream.WriteAsync(request.RasterizedImage, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var result = _tableFormer.Process(tempPath, _generateOverlay, _variant, _runtime, _language);
+            var cells = ConvertRegions(request.BoundingBox, bitmap.Width, bitmap.Height, result.Regions);
+            var rowCount = CountAxisGroups(cells, static cell => (cell.BoundingBox.Top, cell.BoundingBox.Height));
+            var columnCount = CountAxisGroups(cells, static cell => (cell.BoundingBox.Left, cell.BoundingBox.Width));
+            return new TableStructure(request.Page, cells, rowCount, columnCount);
+        }
+        finally
+        {
+            TryDelete(tempPath);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _tableFormer.Dispose();
+        _disposed = true;
+    }
+
+    private static string PrepareWorkingDirectory(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            path = Path.GetTempPath();
+        }
+
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private void EnsureNotDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, nameof(TableFormerTableStructureService));
+    }
+
+    private static IReadOnlyList<TableCell> ConvertRegions(BoundingBox tableBounds, int imageWidth, int imageHeight, IReadOnlyList<TableRegion> regions)
+    {
+        if (imageWidth <= 0 || imageHeight <= 0 || regions.Count == 0)
+        {
+            return Array.Empty<TableCell>();
+        }
+
+        var scaleX = tableBounds.Width / imageWidth;
+        var scaleY = tableBounds.Height / imageHeight;
+        if (double.IsNaN(scaleX) || double.IsInfinity(scaleX) || double.IsNaN(scaleY) || double.IsInfinity(scaleY))
+        {
+            return Array.Empty<TableCell>();
+        }
+
+        var cells = new List<TableCell>(regions.Count);
+        foreach (var region in regions)
+        {
+            if (region.Width <= 0 || region.Height <= 0)
+            {
+                continue;
+            }
+
+            var left = tableBounds.Left + (region.X * scaleX);
+            var top = tableBounds.Top + (region.Y * scaleY);
+            var right = left + (region.Width * scaleX);
+            var bottom = top + (region.Height * scaleY);
+
+            left = Math.Max(tableBounds.Left, left);
+            top = Math.Max(tableBounds.Top, top);
+            right = Math.Min(tableBounds.Right, right);
+            bottom = Math.Min(tableBounds.Bottom, bottom);
+
+            if (!BoundingBox.TryCreate(left, top, right, bottom, out var boundingBox) || boundingBox.IsEmpty)
+            {
+                continue;
+            }
+
+            cells.Add(new TableCell(boundingBox, RowSpan: 1, ColumnSpan: 1, Text: null));
+        }
+
+        return cells.Count == 0
+            ? Array.Empty<TableCell>()
+            : cells;
+    }
+
+    private static int CountAxisGroups(IReadOnlyList<TableCell> cells, Func<TableCell, (double Origin, double Length)> selector)
+    {
+        if (cells.Count == 0)
+        {
+            return 0;
+        }
+
+        var centers = new List<double>();
+        foreach (var cell in cells.OrderBy(c => selector(c).Origin))
+        {
+            var (origin, length) = selector(cell);
+            var size = Math.Max(length, 1d);
+            var center = origin + (size / 2d);
+            var tolerance = Math.Max(size * 0.5d, 1d);
+
+            var match = centers.FindIndex(existing => Math.Abs(existing - center) <= tolerance);
+            if (match < 0)
+            {
+                centers.Add(center);
+            }
+        }
+
+        return centers.Count;
+    }
+
+    private void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException ex)
+        {
+            LogDeleteFailed(_logger, path, ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            LogDeleteFailed(_logger, path, ex);
+        }
+    }
+}
+
+internal interface ITableFormerInvoker : IDisposable
+{
+    TableStructureResult Process(string imagePath, bool overlay, TableFormerModelVariant variant, TableFormerRuntime runtime, TableFormerLanguage? language);
+}
+
+internal sealed class TableFormerInvoker : ITableFormerInvoker
+{
+    private readonly TableFormerSdk.TableFormerSdk _sdk;
+
+    public TableFormerInvoker(TableFormerSdk.TableFormerSdk sdk)
+    {
+        _sdk = sdk ?? throw new ArgumentNullException(nameof(sdk));
+    }
+
+    public TableStructureResult Process(string imagePath, bool overlay, TableFormerModelVariant variant, TableFormerRuntime runtime, TableFormerLanguage? language)
+        => _sdk.Process(imagePath, overlay, variant, runtime, language);
+
+    public void Dispose() => _sdk.Dispose();
+}

--- a/src/Docling.Models/Tables/TableModels.cs
+++ b/src/Docling.Models/Tables/TableModels.cs
@@ -9,7 +9,14 @@ namespace Docling.Models.Tables;
 
 public sealed record TableCell(BoundingBox BoundingBox, int RowSpan, int ColumnSpan, string? Text);
 
-public sealed record TableStructure(PageReference Page, IReadOnlyList<TableCell> Cells, int RowCount, int ColumnCount);
+public sealed record TableStructureDebugArtifact(PageReference Page, ReadOnlyMemory<byte> ImageContent, string MediaType = "image/png");
+
+public sealed record TableStructure(
+    PageReference Page,
+    IReadOnlyList<TableCell> Cells,
+    int RowCount,
+    int ColumnCount,
+    TableStructureDebugArtifact? DebugArtifact = null);
 
 public interface ITableStructureService
 {

--- a/src/Docling.Pipelines/Abstractions/PipelineContextKeys.cs
+++ b/src/Docling.Pipelines/Abstractions/PipelineContextKeys.cs
@@ -34,6 +34,11 @@ public static class PipelineContextKeys
     public const string LayoutItems = "Docling.Pipelines.LayoutItems";
 
     /// <summary>
+    /// Gets the key referencing the inferred table structures for the current document.
+    /// </summary>
+    public const string TableStructures = "Docling.Pipelines.TableStructures";
+
+    /// <summary>
     /// Flag indicating that layout analysis completed successfully.
     /// </summary>
     public const string LayoutAnalysisCompleted = "Docling.Pipelines.LayoutAnalysisCompleted";

--- a/tests/Docling.Tests/Layout/LayoutSdkRunnerTests.cs
+++ b/tests/Docling.Tests/Layout/LayoutSdkRunnerTests.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using Docling.Models.Layout;
+using Xunit;
+
+namespace Docling.Tests.Layout;
+
+public static class LayoutSdkRunnerTests
+{
+    [Fact]
+    public static void RunnerUsesNamespaceOverlayRenderer()
+    {
+        var nestedType = typeof(LayoutSdkRunner).GetNestedType("PassthroughOverlayRenderer", BindingFlags.NonPublic);
+        Assert.Null(nestedType);
+
+        var overlayType = typeof(LayoutSdkRunner).Assembly.GetType("Docling.Models.Layout.PassthroughOverlayRenderer");
+        Assert.NotNull(overlayType);
+        Assert.True(typeof(LayoutSdk.Rendering.IImageOverlayRenderer).IsAssignableFrom(overlayType));
+    }
+}

--- a/tests/Docling.Tests/Tables/TableBuilderTests.cs
+++ b/tests/Docling.Tests/Tables/TableBuilderTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Docling.Core.Geometry;
+using Docling.Core.Primitives;
+using Docling.Models.Tables;
+using Xunit;
+
+namespace Docling.Tests.Tables;
+
+public sealed class TableBuilderTests
+{
+    [Fact]
+    public void BuildProducesPlacementsWithExpectedOrdering()
+    {
+        var page = new PageReference(1, 300);
+        var cells = new List<TableCell>
+        {
+            new(BoundingBox.FromSize(50, 10, 40, 10), RowSpan: 1, ColumnSpan: 1, Text: "b"),
+            new(BoundingBox.FromSize(10, 10, 40, 10), RowSpan: 1, ColumnSpan: 1, Text: "a"),
+            new(BoundingBox.FromSize(10, 30, 40, 10), RowSpan: 1, ColumnSpan: 1, Text: "c"),
+            new(BoundingBox.FromSize(50, 30, 40, 10), RowSpan: 1, ColumnSpan: 1, Text: "d"),
+        };
+        var structure = new TableStructure(page, cells, RowCount: 2, ColumnCount: 2);
+
+        var table = TableBuilder.Build(structure);
+
+        Assert.Equal(2, table.RowCount);
+        Assert.Equal(2, table.ColumnCount);
+        Assert.Equal(4, table.Cells.Count);
+
+        Assert.Equal((0, 0, "a"), (table.Cells[0].RowIndex, table.Cells[0].ColumnIndex, table.Cells[0].Text));
+        Assert.Equal((0, 1, "b"), (table.Cells[1].RowIndex, table.Cells[1].ColumnIndex, table.Cells[1].Text));
+        Assert.Equal((1, 0, "c"), (table.Cells[2].RowIndex, table.Cells[2].ColumnIndex, table.Cells[2].Text));
+        Assert.Equal((1, 1, "d"), (table.Cells[3].RowIndex, table.Cells[3].ColumnIndex, table.Cells[3].Text));
+
+        var bounds = table.BoundingBox;
+        Assert.Equal(10, bounds.Left, 4);
+        Assert.Equal(10, bounds.Top, 4);
+        Assert.Equal(90, bounds.Right, 4);
+        Assert.Equal(40, bounds.Bottom, 4);
+    }
+
+    [Fact]
+    public void BuildNormalizesSpansAndBounds()
+    {
+        var page = new PageReference(2, 200);
+        var cells = new List<TableCell>
+        {
+            new(BoundingBox.FromSize(0, 0, 20, 10), RowSpan: 5, ColumnSpan: -1, Text: "merged"),
+            new(BoundingBox.FromSize(20, 0, 20, 10), RowSpan: 1, ColumnSpan: 1, Text: "right"),
+        };
+        var structure = new TableStructure(page, cells, RowCount: 2, ColumnCount: 2);
+
+        var table = TableBuilder.Build(structure);
+
+        Assert.Equal((0, 0), (table.Cells[0].RowIndex, table.Cells[0].ColumnIndex));
+        Assert.Equal((2, 1), (table.Cells[0].RowSpan, table.Cells[0].ColumnSpan));
+        Assert.Equal((0, 1), (table.Cells[1].RowIndex, table.Cells[1].ColumnIndex));
+        Assert.Equal((1, 1), (table.Cells[1].RowSpan, table.Cells[1].ColumnSpan));
+    }
+
+    [Fact]
+    public void BuildDerivesCountsWhenStructureMissing()
+    {
+        var page = new PageReference(3, 150);
+        var cells = new List<TableCell>
+        {
+            new(BoundingBox.FromSize(0, 0, 10, 10), RowSpan: 1, ColumnSpan: 1, Text: "a"),
+            new(BoundingBox.FromSize(10, 0, 10, 10), RowSpan: 1, ColumnSpan: 1, Text: "b"),
+            new(BoundingBox.FromSize(0, 10, 20, 10), RowSpan: 1, ColumnSpan: 2, Text: "c"),
+        };
+        var structure = new TableStructure(page, cells, RowCount: 0, ColumnCount: 0);
+
+        var table = TableBuilder.Build(structure);
+
+        Assert.Equal(2, table.RowCount);
+        Assert.Equal(2, table.ColumnCount);
+        Assert.Equal(3, table.Cells.Count);
+        Assert.Equal((1, 0), (table.Cells[2].RowIndex, table.Cells[2].ColumnIndex));
+        Assert.Equal((1, 2), (table.Cells[2].RowSpan, table.Cells[2].ColumnSpan));
+    }
+}

--- a/tests/Docling.Tests/Tables/TableFormerTableStructureServiceTests.cs
+++ b/tests/Docling.Tests/Tables/TableFormerTableStructureServiceTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Docling.Core.Geometry;
+using Docling.Core.Primitives;
+using Docling.Models.Tables;
+using Microsoft.Extensions.Logging.Abstractions;
+using SkiaSharp;
+using TableFormerSdk.Enums;
+using TableFormerSdk.Models;
+using TableFormerSdk.Performance;
+using Xunit;
+
+namespace Docling.Tests.Tables;
+
+public sealed class TableFormerTableStructureServiceTests : IDisposable
+{
+    private readonly string _workingDirectory;
+
+    public TableFormerTableStructureServiceTests()
+    {
+        _workingDirectory = Path.Combine(Path.GetTempPath(), $"docling-tests-{Guid.NewGuid():N}");
+    }
+
+    [Fact]
+    public async Task InferStructureAsyncMapsRegionsToCells()
+    {
+        var imageBytes = CreateImageBytes(width: 20, height: 10);
+        var page = new PageReference(1, 300);
+        var bounds = BoundingBox.FromSize(10, 20, 200, 100);
+        var request = new TableStructureRequest(page, bounds, imageBytes);
+
+        var regions = new List<TableRegion>
+        {
+            new(0f, 0f, 10f, 5f, "class_1"),
+            new(10f, 5f, 10f, 5f, "class_1"),
+            new(0f, 0f, 0f, 0f, "invalid") // ignored
+        };
+
+        var snapshot = new TableFormerPerformanceSnapshot(TableFormerRuntime.Onnx, TableFormerModelVariant.Accurate, 1, 1, 10, 10, 10);
+        var result = new TableStructureResult(regions, overlay: null, TableFormerLanguage.English, TableFormerRuntime.Onnx, TimeSpan.FromMilliseconds(25), snapshot);
+        using var invoker = new RecordingInvoker(result);
+
+        var options = new TableFormerStructureServiceOptions
+        {
+            Variant = TableFormerModelVariant.Accurate,
+            Runtime = TableFormerRuntime.Onnx,
+            WorkingDirectory = _workingDirectory,
+        };
+
+        using var service = new TableFormerTableStructureService(options, NullLogger<TableFormerTableStructureService>.Instance, invoker);
+        var structure = await service.InferStructureAsync(request);
+
+        Assert.Equal(page, structure.Page);
+        Assert.Equal(2, structure.Cells.Count);
+        Assert.Equal(2, structure.RowCount);
+        Assert.Equal(2, structure.ColumnCount);
+
+        var first = structure.Cells[0].BoundingBox;
+        Assert.Equal(10, first.Left, 4);
+        Assert.Equal(20, first.Top, 4);
+        Assert.Equal(110, first.Right, 4);
+        Assert.Equal(70, first.Bottom, 4);
+
+        var second = structure.Cells[1].BoundingBox;
+        Assert.Equal(110, second.Left, 4);
+        Assert.Equal(70, second.Top, 4);
+        Assert.Equal(210, second.Right, 4);
+        Assert.Equal(120, second.Bottom, 4);
+
+        Assert.Single(invoker.Invocations);
+        var invocation = invoker.Invocations[0];
+        Assert.False(invocation.Overlay);
+        Assert.Equal(TableFormerModelVariant.Accurate, invocation.Variant);
+        Assert.Equal(TableFormerRuntime.Onnx, invocation.Runtime);
+        Assert.Null(invocation.Language);
+    }
+
+    [Fact]
+    public async Task DisposeReleasesInvoker()
+    {
+        var imageBytes = CreateImageBytes(4, 4);
+        var request = new TableStructureRequest(new PageReference(1, 300), BoundingBox.FromSize(0, 0, 4, 4), imageBytes);
+        var snapshot = new TableFormerPerformanceSnapshot(TableFormerRuntime.Onnx, TableFormerModelVariant.Fast, 1, 1, 1, 1, 1);
+        var result = new TableStructureResult(Array.Empty<TableRegion>(), null, TableFormerLanguage.English, TableFormerRuntime.Onnx, TimeSpan.Zero, snapshot);
+        using var invoker = new RecordingInvoker(result);
+
+        var options = new TableFormerStructureServiceOptions { WorkingDirectory = _workingDirectory };
+        var service = new TableFormerTableStructureService(options, NullLogger<TableFormerTableStructureService>.Instance, invoker);
+        await service.InferStructureAsync(request);
+
+        Assert.False(invoker.Disposed);
+        service.Dispose();
+        Assert.True(invoker.Disposed);
+    }
+
+    [Fact]
+    public async Task InferStructureAsyncReturnsEmptyStructureWhenNoRegions()
+    {
+        var imageBytes = CreateImageBytes(8, 8);
+        var request = new TableStructureRequest(new PageReference(2, 200), BoundingBox.FromSize(5, 6, 40, 40), imageBytes);
+        var snapshot = new TableFormerPerformanceSnapshot(TableFormerRuntime.Onnx, TableFormerModelVariant.Fast, 1, 1, 5, 5, 5);
+        var result = new TableStructureResult(Array.Empty<TableRegion>(), null, TableFormerLanguage.English, TableFormerRuntime.Onnx, TimeSpan.Zero, snapshot);
+        using var invoker = new RecordingInvoker(result);
+
+        var options = new TableFormerStructureServiceOptions { WorkingDirectory = _workingDirectory };
+        using var service = new TableFormerTableStructureService(options, NullLogger<TableFormerTableStructureService>.Instance, invoker);
+        var structure = await service.InferStructureAsync(request);
+
+        Assert.Empty(structure.Cells);
+        Assert.Equal(0, structure.RowCount);
+        Assert.Equal(0, structure.ColumnCount);
+    }
+
+    private static ReadOnlyMemory<byte> CreateImageBytes(int width, int height)
+    {
+        using var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.White);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, quality: 90);
+        return data.ToArray();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_workingDirectory))
+        {
+            Directory.Delete(_workingDirectory, recursive: true);
+        }
+    }
+
+    private sealed class RecordingInvoker : ITableFormerInvoker
+    {
+        private readonly TableStructureResult _result;
+
+        public RecordingInvoker(TableStructureResult result)
+        {
+            _result = result;
+        }
+
+        public List<(string Path, bool Overlay, TableFormerModelVariant Variant, TableFormerRuntime Runtime, TableFormerLanguage? Language)> Invocations { get; } = new();
+
+        public bool Disposed { get; private set; }
+
+        public TableStructureResult Process(string imagePath, bool overlay, TableFormerModelVariant variant, TableFormerRuntime runtime, TableFormerLanguage? language)
+        {
+            Invocations.Add((imagePath, overlay, variant, runtime, language));
+            return _result;
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add table domain entities (`TableItem`, `TableCellItem`) to represent structured grid output
- implement a static TableBuilder that maps TableFormer structures into table items with span reconciliation and derived bounds
- cover the new builder with unit tests and mark backlog item DLN-025 as complete

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68ce961ce3748325a7fa6912570ce84d